### PR TITLE
Add risk query FastAPI service

### DIFF
--- a/risk_query_service/.env.example
+++ b/risk_query_service/.env.example
@@ -1,0 +1,18 @@
+# Core API configuration
+API_KEY=change-me
+
+# Preferred: use a locally synced OneDrive folder
+ONEDRIVE_LOCAL_PATH=/path/to/OneDrive/NWBC files- UAR
+
+# Fallback: Microsoft Graph client credentials
+MS_TENANT_ID=
+MS_CLIENT_ID=
+MS_CLIENT_SECRET=
+MS_DRIVE_ID=
+MS_FOLDER_PATH=/NWBC files- UAR
+
+# Optional settings
+ENABLE_CORS=false
+CACHE_DIR=./cache
+FILE_INDEX_TTL=60
+GRAPH_CACHE_TTL=900

--- a/risk_query_service/Dockerfile
+++ b/risk_query_service/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1
+WORKDIR /app
+
+COPY requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+CMD ["uvicorn", "risk_query_service.app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/risk_query_service/Makefile
+++ b/risk_query_service/Makefile
@@ -1,0 +1,21 @@
+PYTHON=python3
+PIP=pip3
+APP=risk_query_service.app:app
+IMAGE=risk-query-service
+
+.PHONY: install run test docker fmt
+
+install:
+	$(PIP) install -r requirements.txt
+
+run:
+	uvicorn $(APP) --reload
+
+test:
+	pytest
+
+docker:
+	docker build -t $(IMAGE) .
+
+fmt:
+	@echo "No formatters configured"

--- a/risk_query_service/README.md
+++ b/risk_query_service/README.md
@@ -1,0 +1,106 @@
+# Risk Query Service
+
+A production-ready FastAPI microservice that exposes OneDrive-based risk action and permission reports to Microsoft Copilot Studio.
+
+## Features
+
+- Lazy TSV parsing with [Polars](https://www.pola.rs/) for 200k+ line datasets
+- Supports locally synced OneDrive folders and Microsoft Graph fallback
+- Cursor-based pagination and top-N summaries optimised for Copilot tools
+- Swagger 2.0 export compatible with Copilot Studio Custom Connectors
+- API key authentication via the `x-api-key` header
+
+## Getting started
+
+### 1. Clone and install
+
+```bash
+make install
+```
+
+### 2. Configure environment
+
+Copy the template and edit as required:
+
+```bash
+cp .env.example .env
+```
+
+Key variables:
+
+- `API_KEY`: Shared secret required in the `x-api-key` header.
+- `ONEDRIVE_LOCAL_PATH`: Preferred mode – absolute path to the synced folder containing `RS_*` files.
+- `MS_TENANT_ID`, `MS_CLIENT_ID`, `MS_CLIENT_SECRET`, `MS_DRIVE_ID`, `MS_FOLDER_PATH`: Microsoft Graph credentials when a local path is unavailable.
+- `ENABLE_CORS`: Set to `true` to allow browser-based integrations.
+
+### 3. Run the service
+
+```bash
+make run
+```
+
+The API will be available at `http://127.0.0.1:8000`.
+
+### 4. Authenticate requests
+
+All endpoints require `x-api-key: <API_KEY>`.
+
+### 5. Example requests
+
+Fetch schema metadata:
+
+```bash
+curl -H "x-api-key: $API_KEY" http://127.0.0.1:8000/meta/schema
+```
+
+Query high-risk actions (50 row default):
+
+```bash
+curl -G \
+  -H "x-api-key: $API_KEY" \
+  --data-urlencode "risk_level=High" \
+  --data-urlencode "limit=50" \
+  http://127.0.0.1:8000/risk/actions/query
+```
+
+Summarise by risk level:
+
+```bash
+curl -G \
+  -H "x-api-key: $API_KEY" \
+  --data-urlencode "groupby=Risk Level" \
+  http://127.0.0.1:8000/risk/actions/summary
+```
+
+### Swagger 2.0 for Copilot Studio
+
+The standard OpenAPI 3 document is exposed at `/openapi.json`. A converted Swagger 2.0 document is available at `/swagger2.json`:
+
+```bash
+curl -H "x-api-key: $API_KEY" http://127.0.0.1:8000/swagger2.json
+```
+
+Use the Swagger 2.0 JSON when creating a Custom Connector (REST API) in Copilot Studio. Map the connector's security settings to pass the `x-api-key` header.
+
+## Microsoft Graph mode
+
+When `ONEDRIVE_LOCAL_PATH` is unset, the service automatically downloads the latest files from OneDrive via the Microsoft Graph API. Files are cached in `CACHE_DIR` and refreshed every 15 minutes per report type. Ensure the app registration has `Files.Read.All` application permissions.
+
+## Development workflow
+
+- `make test` – run the pytest suite (uses sample fixtures)
+- `make docker` – build the production container image
+- `make fmt` – placeholder target for future formatters
+
+## Running inside Docker
+
+```bash
+docker build -t risk-query-service .
+docker run --rm -p 8000:8000 --env-file .env risk-query-service
+```
+
+## Notes
+
+- The service never loads entire files into memory; Polars lazy scans keep memory usage predictable.
+- Latest report selection is cached for 60 seconds. File hashes guard cursor validity.
+- Requests exceeding three seconds are flagged as `partial` with a continuation cursor.

--- a/risk_query_service/app.py
+++ b/risk_query_service/app.py
@@ -1,0 +1,93 @@
+"""Main FastAPI application for the risk query service."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from dotenv import load_dotenv
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.openapi.utils import get_openapi
+from fastapi.responses import ORJSONResponse
+
+from .config import get_settings
+from .routers import actions, health, meta, permissions
+from .security import API_KEY_HEADER, API_KEY_HEADER_NAME
+from .utils.logging import configure_logging
+from .utils.swagger2 import SwaggerConversionError, convert_openapi3_to_swagger2
+
+load_dotenv()
+configure_logging()
+
+settings = get_settings()
+
+app = FastAPI(
+    title="Risk Query Service",
+    version="1.0.0",
+    default_response_class=ORJSONResponse,
+    description="FastAPI service exposing risk action and permission datasets.",
+)
+
+headers = ["*"]
+if API_KEY_HEADER_NAME not in headers:
+    headers.append(API_KEY_HEADER_NAME)
+
+if settings.enable_cors:
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=headers,
+    )
+
+app.include_router(health.router)
+app.include_router(meta.router)
+app.include_router(actions.router)
+app.include_router(permissions.router)
+
+
+def custom_openapi() -> Dict[str, Any]:
+    if app.openapi_schema:
+        return app.openapi_schema
+    openapi_schema = get_openapi(
+        title=app.title,
+        version=app.version,
+        description=app.description,
+        routes=app.routes,
+    )
+    components = openapi_schema.setdefault("components", {})
+    security_schemes = components.setdefault("securitySchemes", {})
+    security_schemes["ApiKeyAuth"] = {
+        "type": "apiKey",
+        "in": "header",
+        "name": API_KEY_HEADER_NAME,
+    }
+    openapi_schema["security"] = [{"ApiKeyAuth": []}]
+    app.openapi_schema = openapi_schema
+    return app.openapi_schema
+
+
+app.openapi = custom_openapi  # type: ignore[assignment]
+
+
+@app.on_event("startup")
+async def _build_swagger2() -> None:
+    try:
+        openapi = app.openapi()
+        swagger2 = convert_openapi3_to_swagger2(openapi)
+        app.state.swagger2 = swagger2
+    except SwaggerConversionError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@app.get("/swagger2.json", include_in_schema=False)
+def get_swagger2() -> Dict[str, Any]:
+    swagger2 = getattr(app.state, "swagger2", None)
+    if swagger2 is None:
+        openapi = app.openapi()
+        swagger2 = convert_openapi3_to_swagger2(openapi)
+        app.state.swagger2 = swagger2
+    return swagger2
+
+
+__all__ = ["app"]

--- a/risk_query_service/config.py
+++ b/risk_query_service/config.py
@@ -1,0 +1,57 @@
+"""Application configuration management."""
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+from typing import Optional
+
+from pydantic import AliasChoices, Field
+from pydantic import field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Runtime configuration loaded from environment variables."""
+
+    api_key: str = Field(default="", validation_alias=AliasChoices("API_KEY"))
+    onedrive_local_path: Optional[Path] = Field(default=None, validation_alias=AliasChoices("ONEDRIVE_LOCAL_PATH"))
+
+    ms_tenant_id: Optional[str] = Field(default=None, validation_alias=AliasChoices("MS_TENANT_ID"))
+    ms_client_id: Optional[str] = Field(default=None, validation_alias=AliasChoices("MS_CLIENT_ID"))
+    ms_client_secret: Optional[str] = Field(default=None, validation_alias=AliasChoices("MS_CLIENT_SECRET"))
+    ms_drive_id: Optional[str] = Field(default=None, validation_alias=AliasChoices("MS_DRIVE_ID"))
+    ms_folder_path: Optional[str] = Field(default=None, validation_alias=AliasChoices("MS_FOLDER_PATH"))
+
+    cache_dir: Path = Field(default=Path("cache"), validation_alias=AliasChoices("CACHE_DIR"))
+    file_index_ttl_seconds: int = Field(default=60, validation_alias=AliasChoices("FILE_INDEX_TTL"))
+    graph_cache_ttl_seconds: int = Field(default=900, validation_alias=AliasChoices("GRAPH_CACHE_TTL"))
+
+    enable_cors: bool = Field(default=False, validation_alias=AliasChoices("ENABLE_CORS"))
+
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", case_sensitive=False)
+
+    @field_validator("cache_dir", mode="before")
+    def _expand_cache_dir(cls, value: str | Path) -> Path:
+        path = Path(value)
+        return path.expanduser().resolve()
+
+    @field_validator("onedrive_local_path", mode="before")
+    def _expand_local_path(cls, value: Optional[str | Path]) -> Optional[Path]:
+        if value in (None, ""):
+            return None
+        return Path(value).expanduser().resolve()
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> Settings:
+    """Return a cached settings instance."""
+
+    settings = Settings()
+    settings.cache_dir.mkdir(parents=True, exist_ok=True)
+    return settings
+
+
+def reset_settings_cache() -> None:
+    """Clear the cached settings (primarily for tests)."""
+
+    get_settings.cache_clear()

--- a/risk_query_service/datasets.py
+++ b/risk_query_service/datasets.py
@@ -1,0 +1,179 @@
+"""Dataset access utilities built on Polars lazy execution."""
+from __future__ import annotations
+
+import hashlib
+import itertools
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+import polars as pl
+
+from .file_index import FileRecord, ReportType, get_latest_file_with_hash
+from .utils.schema import CANONICAL_COLUMNS, CANONICAL_TYPES, DEFAULT_COLUMNS, canonicalize_columns
+
+
+@dataclass
+class DatasetBundle:
+    lazyframe: pl.LazyFrame
+    file_hash: str
+    report_type: str
+
+
+def scan_report(path: Path) -> pl.LazyFrame:
+    """Scan a TSV report lazily."""
+
+    return pl.scan_csv(
+        path,
+        separator="\t",
+        has_header=True,
+        ignore_errors=True,
+        infer_schema_length=100,
+    )
+
+
+def _normalize_lazyframe(lf: pl.LazyFrame, report_type: ReportType, file_path: Path) -> pl.LazyFrame:
+    columns = lf.columns
+    missing = [name for name in CANONICAL_COLUMNS if name not in columns]
+    for name in missing:
+        if name == "IsCritical":
+            lf = lf.with_columns(pl.lit(False).alias("IsCritical"))
+        else:
+            lf = lf.with_columns(pl.lit(None).cast(CANONICAL_TYPES[name]).alias(name))
+
+    if "IsCritical" in columns:
+        lf = lf.with_columns(pl.col("IsCritical").cast(pl.Boolean))
+
+    is_critical = "crit" in file_path.stem.lower()
+    lf = lf.with_columns(
+        pl.lit(is_critical).alias("IsCritical"),
+        pl.lit(_report_type_label(report_type, is_critical)).alias("ReportType"),
+    )
+    return lf.select(CANONICAL_COLUMNS)
+
+
+def _report_type_label(report_type: ReportType, is_critical: bool) -> str:
+    if report_type in {"actions", "crit_actions"}:
+        return "Critical Action" if is_critical else "Action"
+    if report_type in {"perms", "crit_perms"}:
+        return "Critical Permission" if is_critical else "Permission"
+    return report_type
+
+
+def _load_bundle(report_type: ReportType) -> Tuple[pl.LazyFrame, FileRecord]:
+    record = get_latest_file_with_hash(report_type)
+    lf = scan_report(record.path)
+    lf = _normalize_lazyframe(lf, report_type, record.path)
+    return lf, record
+
+
+def _combine_frames(report_types: Iterable[ReportType]) -> DatasetBundle:
+    frames: List[pl.LazyFrame] = []
+    hashes: List[str] = []
+    canonical_report: Optional[str] = None
+    for report_type in report_types:
+        lf, record = _load_bundle(report_type)
+        frames.append(lf)
+        hashes.append(record.file_hash)
+        canonical_report = canonical_report or report_type
+    lazyframe = pl.concat(frames, how="vertical") if len(frames) > 1 else frames[0]
+    combined_hash = hashlib.sha1("|".join(hashes).encode("utf-8")).hexdigest()
+    report_label = "actions" if canonical_report in {"actions", "crit_actions"} else "permissions"
+    return DatasetBundle(lazyframe=lazyframe, file_hash=combined_hash, report_type=report_label)
+
+
+actions_bundle = lambda: _combine_frames(["actions", "crit_actions"])  # noqa: E731
+permissions_bundle = lambda: _combine_frames(["perms", "crit_perms"])  # noqa: E731
+
+
+FILTERABLE_COLUMNS = {
+    "user": ["User ID", "User Name"],
+    "role": "Role ID",
+    "risk_level": "Risk Level",
+    "system": "System",
+    "action": "Action",
+}
+
+
+def apply_filters(
+    lf: pl.LazyFrame,
+    *,
+    user: Optional[str] = None,
+    role: Optional[str] = None,
+    risk_level: Optional[str] = None,
+    system: Optional[str] = None,
+    action: Optional[str] = None,
+    date_from: Optional[date] = None,
+    date_to: Optional[date] = None,
+) -> pl.LazyFrame:
+    exprs: List[pl.Expr] = []
+
+    if user:
+        term = user.lower()
+        exprs.append(
+            pl.any_horizontal(
+                [pl.col(col).cast(pl.Utf8).str.to_lowercase().str.contains(term) for col in FILTERABLE_COLUMNS["user"]]
+            )
+        )
+    if role:
+        exprs.append(pl.col("Role ID").cast(pl.Utf8).str.to_lowercase() == role.lower())
+    if risk_level:
+        exprs.append(pl.col("Risk Level").cast(pl.Utf8).str.to_lowercase() == risk_level.lower())
+    if system:
+        exprs.append(pl.col("System").cast(pl.Utf8).str.to_lowercase() == system.lower())
+    if action:
+        exprs.append(pl.col("Action").cast(pl.Utf8).str.to_lowercase() == action.lower())
+
+    if date_from or date_to:
+        parsed = pl.col("Last Executed On").str.strptime(pl.Date, strict=False, format=None)
+        if date_from:
+            exprs.append(parsed >= pl.lit(date_from))
+        if date_to:
+            exprs.append(parsed <= pl.lit(date_to))
+
+    for expr in exprs:
+        lf = lf.filter(expr)
+    return lf
+
+
+def paginate_collect(lf: pl.LazyFrame, limit: int, offset: int) -> Tuple[List[Dict[str, object]], bool]:
+    window = lf.slice(offset, limit + 1)
+    result = window.collect()
+    rows = result.to_dicts()
+    has_more = len(rows) > limit
+    if has_more:
+        rows = rows[:limit]
+    return rows, has_more
+
+
+def select_columns(lf: pl.LazyFrame, columns: Optional[List[str]]) -> pl.LazyFrame:
+    if columns:
+        resolved = canonicalize_columns(columns)
+    else:
+        resolved = DEFAULT_COLUMNS
+    return lf.select(resolved)
+
+
+def summarize(lf: pl.LazyFrame, groupby: str, top: int) -> List[Dict[str, object]]:
+    summary = (
+        lf.group_by(groupby)
+        .agg(
+            [
+                pl.len().alias("count"),
+                pl.col("User Name").drop_nulls().head(3).alias("examples"),
+            ]
+        )
+        .sort("count", descending=True)
+        .limit(top)
+        .collect()
+    )
+    records = []
+    for row in summary.iter_rows(named=True):
+        records.append({"group": row[groupby], "count": row["count"], "examples": row["examples"]})
+    return records
+
+
+def infer_schema(lf: pl.LazyFrame) -> Dict[str, str]:
+    schema = lf.schema
+    return {name: dtype.__class__.__name__ for name, dtype in schema.items()}

--- a/risk_query_service/file_index.py
+++ b/risk_query_service/file_index.py
@@ -1,0 +1,156 @@
+"""File discovery and indexing for report selection."""
+from __future__ import annotations
+
+import re
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Literal, Optional, Tuple
+
+from cachetools import TTLCache
+
+from .config import get_settings
+from .graph_client import iter_remote_files
+
+ReportType = Literal["actions", "crit_actions", "perms", "crit_perms"]
+
+FILE_PATTERNS: Dict[ReportType, re.Pattern[str]] = {
+    "actions": re.compile(r"^RS_Action_Lvl_(\d{8})_(\d{6})\.txt$"),
+    "crit_actions": re.compile(r"^RS_CritAction_Lvl_(\d{8})_(\d{6})\.txt$"),
+    "perms": re.compile(r"^RS_Perm_Lvl_(\d{8})_(\d{6})\.txt$"),
+    "crit_perms": re.compile(r"^RS_CritPerm_Lvl_(\d{8})_(\d{6})\.txt$"),
+}
+
+
+@dataclass(frozen=True)
+class FileRecord:
+    report_type: ReportType
+    path: Path
+    timestamp: float
+    file_hash: str
+
+
+_file_cache: TTLCache[ReportType, FileRecord] | None = None
+_settings = None
+
+
+def _ensure_cache() -> None:
+    global _file_cache, _settings
+    if _file_cache is None:
+        _settings = get_settings()
+        _file_cache = TTLCache(maxsize=16, ttl=_settings.file_index_ttl_seconds)
+
+
+def clear_file_cache() -> None:
+    if _file_cache is not None:
+        _file_cache.clear()
+
+
+def _parse_timestamp(match: re.Match[str]) -> float:
+    date_part, time_part = match.groups()
+    return time.mktime(time.strptime(date_part + time_part, "%Y%m%d%H%M%S"))
+
+
+def _compute_file_hash(path: Path) -> str:
+    stat = path.stat()
+    return f"{path.name}:{stat.st_size}:{int(stat.st_mtime)}"
+
+
+def _discover_local_files(pattern: re.Pattern[str]) -> List[Tuple[Path, float]]:
+    settings = get_settings()
+    folder = settings.onedrive_local_path
+    if not folder:
+        return []
+    matches: List[Tuple[Path, float]] = []
+    for file in folder.iterdir():
+        if not file.is_file():
+            continue
+        match = pattern.match(file.name)
+        if match:
+            ts = _parse_timestamp(match)
+            matches.append((file, ts))
+    return matches
+
+
+def _discover_remote_files(pattern: re.Pattern[str]) -> List[Tuple[Path, float]]:
+    names = []
+    settings = get_settings()
+    folder = settings.onedrive_local_path
+    if folder:
+        return []
+    client_files: Dict[str, Path] = {}
+    for report_type, regex in FILE_PATTERNS.items():
+        if regex is pattern:
+            names = [name for name in _list_all_remote_names() if regex.match(name)]
+            break
+    if not names:
+        return []
+    client_files = iter_remote_files(names)
+    results: List[Tuple[Path, float]] = []
+    for name, path in client_files.items():
+        match = pattern.match(name)
+        if not match:
+            continue
+        ts = _parse_timestamp(match)
+        results.append((path, ts))
+    return results
+
+_remote_names_cache: Optional[List[str]] = None
+_remote_names_timestamp: float = 0.0
+
+
+def _list_all_remote_names() -> List[str]:
+    global _remote_names_cache, _remote_names_timestamp
+    settings = get_settings()
+    if settings.onedrive_local_path:
+        return []
+    now = time.time()
+    if _remote_names_cache and (now - _remote_names_timestamp) < settings.graph_cache_ttl_seconds:
+        return _remote_names_cache
+    from .graph_client import GraphClient
+
+    client = GraphClient()
+    files = client.list_files()
+    _remote_names_cache = [file.name for file in files]
+    _remote_names_timestamp = now
+    return _remote_names_cache
+
+
+def _discover_files(report_type: ReportType) -> Optional[FileRecord]:
+    _ensure_cache()
+    pattern = FILE_PATTERNS[report_type]
+    matches = _discover_local_files(pattern)
+    if not matches:
+        matches = _discover_remote_files(pattern)
+    if not matches:
+        return None
+    matches.sort(key=lambda item: item[1], reverse=True)
+    path, ts = matches[0]
+    file_hash = _compute_file_hash(path)
+    return FileRecord(report_type=report_type, path=path, timestamp=ts, file_hash=file_hash)
+
+
+def get_latest_file(report_type: ReportType) -> Path:
+    """Return the latest file path for the given report type."""
+
+    _ensure_cache()
+    assert _file_cache is not None
+    record = _file_cache.get(report_type)
+    if record is None:
+        record = _discover_files(report_type)
+        if record is None:
+            raise FileNotFoundError(f"No files found for report type {report_type}")
+        _file_cache[report_type] = record
+    return record.path
+
+
+def get_latest_file_with_hash(report_type: ReportType) -> FileRecord:
+    _ensure_cache()
+    assert _file_cache is not None
+    record = _file_cache.get(report_type)
+    if record is None:
+        record = _discover_files(report_type)
+        if record is None:
+            raise FileNotFoundError(f"No files found for report type {report_type}")
+        _file_cache[report_type] = record
+    return record

--- a/risk_query_service/graph_client.py
+++ b/risk_query_service/graph_client.py
@@ -1,0 +1,120 @@
+"""Minimal Microsoft Graph client for OneDrive file access."""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+import requests
+from cachetools import TTLCache
+
+from .config import get_settings
+
+GRAPH_SCOPE = "https://graph.microsoft.com/.default"
+TOKEN_URL_TEMPLATE = "https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
+
+
+@dataclass
+class GraphFile:
+    name: str
+    download_url: str
+    size: int
+    last_modified: str
+
+
+class GraphClient:
+    """Client wrapping the minimal Graph API calls required for the service."""
+
+    def __init__(self) -> None:
+        self.settings = get_settings()
+        self._token_cache: TTLCache[str, str] = TTLCache(maxsize=1, ttl=3500)
+        self._listing_cache: TTLCache[str, List[GraphFile]] = TTLCache(maxsize=8, ttl=self.settings.graph_cache_ttl_seconds)
+
+    def _get_token(self) -> str:
+        cached = self._token_cache.get("token")
+        if cached:
+            return cached
+
+        tenant = self.settings.ms_tenant_id
+        client_id = self.settings.ms_client_id
+        client_secret = self.settings.ms_client_secret
+        if not all([tenant, client_id, client_secret]):
+            raise RuntimeError("Microsoft Graph credentials are not configured")
+
+        data = {
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "grant_type": "client_credentials",
+            "scope": GRAPH_SCOPE,
+        }
+        url = TOKEN_URL_TEMPLATE.format(tenant_id=tenant)
+        response = requests.post(url, data=data, timeout=10)
+        response.raise_for_status()
+        token = response.json()["access_token"]
+        self._token_cache["token"] = token
+        return token
+
+    def list_files(self) -> List[GraphFile]:
+        cache_key = "files"
+        cached = self._listing_cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        token = self._get_token()
+        headers = {"Authorization": f"Bearer {token}"}
+        folder_path = self.settings.ms_folder_path
+        if not folder_path:
+            raise RuntimeError("MS_FOLDER_PATH must be configured for Microsoft Graph mode")
+
+        drive_id = self.settings.ms_drive_id
+        if drive_id:
+            url = f"https://graph.microsoft.com/v1.0/drives/{drive_id}/root:{folder_path}:/children"
+        else:
+            url = f"https://graph.microsoft.com/v1.0/me/drive/root:{folder_path}:/children"
+
+        response = requests.get(url, headers=headers, timeout=10)
+        response.raise_for_status()
+        values = response.json().get("value", [])
+
+        files: List[GraphFile] = []
+        for item in values:
+            download_url = item.get("@microsoft.graph.downloadUrl")
+            name = item.get("name")
+            if not download_url or not name:
+                continue
+            files.append(
+                GraphFile(
+                    name=name,
+                    download_url=download_url,
+                    size=int(item.get("size", 0)),
+                    last_modified=item.get("lastModifiedDateTime", ""),
+                )
+            )
+
+        self._listing_cache[cache_key] = files
+        return files
+
+    def ensure_cached(self, filename: str) -> Path:
+        """Download the given file if not already cached locally."""
+
+        cache_dir = self.settings.cache_dir
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        target = cache_dir / filename
+        if target.exists() and (time.time() - target.stat().st_mtime) < self.settings.graph_cache_ttl_seconds:
+            return target
+
+        files = self.list_files()
+        match = next((file for file in files if file.name == filename), None)
+        if not match:
+            raise FileNotFoundError(f"File {filename} not found in Microsoft Graph folder")
+
+        response = requests.get(match.download_url, timeout=30)
+        response.raise_for_status()
+        target.write_bytes(response.content)
+        return target
+
+
+def iter_remote_files(names: Iterable[str]) -> Dict[str, Path]:
+    client = GraphClient()
+    return {name: client.ensure_cached(name) for name in names}

--- a/risk_query_service/requirements.txt
+++ b/risk_query_service/requirements.txt
@@ -1,0 +1,13 @@
+fastapi==0.115.4
+uvicorn[standard]==0.30.6
+polars==0.20.31
+pyarrow==15.0.0
+pydantic==2.7.4
+pydantic-settings==2.2.1
+python-dotenv==1.0.1
+requests==2.31.0
+cachetools==5.3.3
+orjson==3.9.15
+loguru==0.7.2
+pytest==8.0.2
+httpx==0.27.0

--- a/risk_query_service/routers/actions.py
+++ b/risk_query_service/routers/actions.py
@@ -1,0 +1,200 @@
+"""Risk action query endpoints."""
+from __future__ import annotations
+
+import time
+from datetime import date
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from ..datasets import (
+    actions_bundle,
+    apply_filters,
+    paginate_collect,
+    select_columns,
+    summarize,
+)
+from ..security import require_api_key
+from ..utils.logging import log_request_summary
+from ..utils.paginate import (
+    Cursor,
+    build_initial_cursor,
+    encode_cursor,
+    maybe_decode_cursor,
+    next_cursor,
+)
+
+router = APIRouter(prefix="/risk/actions", tags=["Risk Actions"], dependencies=[Depends(require_api_key)])
+
+
+class QueryResponse(BaseModel):
+    data: List[Dict[str, Any]]
+    cursor: Optional[str] = None
+    has_more: bool
+    partial: bool = False
+    file_hash: str
+    report_type: str
+
+
+class SummaryItem(BaseModel):
+    group: Any
+    count: int
+    examples: List[Any] = Field(default_factory=list)
+
+
+class SummaryResponse(BaseModel):
+    data: List[SummaryItem]
+    report_type: str
+
+
+MAX_LIMIT = 200
+DEFAULT_LIMIT = 50
+SUMMARY_GROUPS = {"Role ID", "User Name", "Risk Level", "Action", "System"}
+
+
+def _parse_date(value: Optional[str]) -> Optional[date]:
+    if value in (None, ""):
+        return None
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:  # noqa: BLE001
+        raise HTTPException(status_code=400, detail=f"Invalid date value '{value}'") from exc
+
+
+def _prepare_columns(columns: Optional[str]) -> Optional[List[str]]:
+    if not columns:
+        return None
+    items = [item.strip() for item in columns.split(",") if item.strip()]
+    if not items:
+        return None
+    return items
+
+
+@router.get("/query", response_model=QueryResponse)
+def query_actions(
+    *,
+    user: Optional[str] = Query(None, description="Filter by user (substring match)"),
+    role: Optional[str] = Query(None, description="Filter by role ID"),
+    risk_level: Optional[str] = Query(None, description="Filter by risk level"),
+    system: Optional[str] = Query(None, description="Filter by system"),
+    action: Optional[str] = Query(None, description="Filter by action"),
+    date_from: Optional[str] = Query(None, description="Filter from date (YYYY-MM-DD)"),
+    date_to: Optional[str] = Query(None, description="Filter to date (YYYY-MM-DD)"),
+    columns: Optional[str] = Query(None, description="Comma separated list of columns"),
+    limit: int = Query(DEFAULT_LIMIT, ge=1, le=MAX_LIMIT),
+    cursor: Optional[str] = Query(None, description="Opaque cursor token"),
+    offset: int = Query(0, ge=0, description="Offset (ignored when cursor is provided)"),
+) -> QueryResponse:
+    bundle = actions_bundle()
+    parsed_from = _parse_date(date_from)
+    parsed_to = _parse_date(date_to)
+
+    cursor_obj = maybe_decode_cursor(cursor)
+    effective_offset = offset
+    if cursor_obj:
+        if cursor_obj.file_hash != bundle.file_hash:
+            effective_offset = 0
+            cursor_obj = build_initial_cursor(bundle.file_hash, bundle.report_type)
+        else:
+            effective_offset = cursor_obj.offset
+    else:
+        cursor_obj = build_initial_cursor(bundle.file_hash, bundle.report_type, offset)
+
+    lf = bundle.lazyframe
+    lf = apply_filters(
+        lf,
+        user=user,
+        role=role,
+        risk_level=risk_level,
+        system=system,
+        action=action,
+        date_from=parsed_from,
+        date_to=parsed_to,
+    )
+    lf = select_columns(lf, _prepare_columns(columns))
+
+    start = time.perf_counter()
+    rows, has_more = paginate_collect(lf, limit, effective_offset)
+    duration = time.perf_counter() - start
+    partial = duration > 3.0
+
+    if has_more:
+        next_cur = next_cursor(cursor_obj, len(rows))
+        cursor_token = encode_cursor(next_cur)
+    else:
+        cursor_token = None
+
+    log_request_summary(
+        "/risk/actions/query",
+        filters={
+            "user": user,
+            "role": role,
+            "risk_level": risk_level,
+            "system": system,
+            "action": action,
+            "date_from": date_from,
+            "date_to": date_to,
+        },
+        rows_returned=len(rows),
+        has_more=has_more,
+        partial=partial,
+        latency_ms=int(duration * 1000),
+    )
+
+    return QueryResponse(
+        data=rows,
+        cursor=cursor_token,
+        has_more=has_more,
+        partial=partial,
+        file_hash=bundle.file_hash,
+        report_type=bundle.report_type,
+    )
+
+
+@router.get("/summary", response_model=SummaryResponse)
+def summary_actions(
+    *,
+    groupby: str = Query(..., description="Column to group by"),
+    top: int = Query(20, ge=1, le=100),
+    user: Optional[str] = None,
+    role: Optional[str] = None,
+    risk_level: Optional[str] = None,
+    system: Optional[str] = None,
+    action: Optional[str] = None,
+    date_from: Optional[str] = None,
+    date_to: Optional[str] = None,
+) -> SummaryResponse:
+    canonical_group = groupby.strip()
+    if canonical_group not in SUMMARY_GROUPS:
+        raise HTTPException(status_code=400, detail="Unsupported groupby column")
+
+    bundle = actions_bundle()
+    parsed_from = _parse_date(date_from)
+    parsed_to = _parse_date(date_to)
+    lf = apply_filters(
+        bundle.lazyframe,
+        user=user,
+        role=role,
+        risk_level=risk_level,
+        system=system,
+        action=action,
+        date_from=parsed_from,
+        date_to=parsed_to,
+    )
+    records = summarize(lf, canonical_group, top)
+
+    log_request_summary(
+        "/risk/actions/summary",
+        filters={
+            "groupby": groupby,
+            "user": user,
+            "role": role,
+            "risk_level": risk_level,
+            "system": system,
+            "action": action,
+        },
+        rows_returned=len(records),
+    )
+
+    return SummaryResponse(data=records, report_type=bundle.report_type)

--- a/risk_query_service/routers/health.py
+++ b/risk_query_service/routers/health.py
@@ -1,0 +1,23 @@
+"""Health check endpoints."""
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+
+from ..file_index import FILE_PATTERNS, get_latest_file
+
+router = APIRouter(prefix="/health", tags=["Health"])
+
+
+@router.get("/live")
+def live() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@router.get("/ready")
+def ready() -> dict[str, str]:
+    for report_type in FILE_PATTERNS:
+        try:
+            get_latest_file(report_type)
+        except FileNotFoundError as exc:
+            raise HTTPException(status_code=503, detail=str(exc)) from exc
+    return {"status": "ok"}

--- a/risk_query_service/routers/meta.py
+++ b/risk_query_service/routers/meta.py
@@ -1,0 +1,53 @@
+"""Metadata endpoints for schema and facets."""
+from __future__ import annotations
+
+from typing import Dict, List
+
+import polars as pl
+from fastapi import APIRouter, HTTPException, Query
+
+from ..datasets import actions_bundle, infer_schema, permissions_bundle
+from ..utils.schema import CANONICAL_COLUMNS
+
+router = APIRouter(prefix="/meta", tags=["Metadata"])
+
+
+def _resolve_column(column: str) -> str:
+    mapping = {name.lower(): name for name in CANONICAL_COLUMNS}
+    key = column.lower()
+    if key not in mapping:
+        raise HTTPException(status_code=400, detail=f"Unknown column '{column}'")
+    return mapping[key]
+
+
+schema_cache: dict[tuple[str, str], Dict[str, str]] = {}
+
+
+@router.get("/schema")
+def get_schema() -> Dict[str, str]:
+    actions = actions_bundle()
+    permissions = permissions_bundle()
+    key = (actions.file_hash, permissions.file_hash)
+    if key not in schema_cache:
+        combined = pl.concat([actions.lazyframe, permissions.lazyframe], how="diagonal_relaxed")
+        schema_cache[key] = infer_schema(combined)
+    return schema_cache[key]
+
+
+@router.get("/facets")
+def get_facets(column: str = Query(..., description="Column name"), n: int = Query(20, ge=1, le=100)) -> List[Dict[str, object]]:
+    canonical = _resolve_column(column)
+    actions = actions_bundle()
+    permissions = permissions_bundle()
+    combined = pl.concat([actions.lazyframe, permissions.lazyframe], how="vertical")
+    result = (
+        combined.group_by(canonical)
+        .agg(pl.len().alias("count"))
+        .sort("count", descending=True)
+        .limit(n)
+        .collect()
+    )
+    facets: List[Dict[str, object]] = []
+    for row in result.iter_rows(named=True):
+        facets.append({"value": row[canonical], "count": row["count"]})
+    return facets

--- a/risk_query_service/routers/permissions.py
+++ b/risk_query_service/routers/permissions.py
@@ -1,0 +1,194 @@
+"""Risk permission query endpoints."""
+from __future__ import annotations
+
+import time
+from datetime import date
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from ..datasets import (
+    permissions_bundle,
+    apply_filters,
+    paginate_collect,
+    select_columns,
+    summarize,
+)
+from ..security import require_api_key
+from ..utils.logging import log_request_summary
+from ..utils.paginate import build_initial_cursor, encode_cursor, maybe_decode_cursor, next_cursor
+
+router = APIRouter(prefix="/risk/permissions", tags=["Risk Permissions"], dependencies=[Depends(require_api_key)])
+
+
+class QueryResponse(BaseModel):
+    data: List[Dict[str, Any]]
+    cursor: Optional[str] = None
+    has_more: bool
+    partial: bool = False
+    file_hash: str
+    report_type: str
+
+
+class SummaryItem(BaseModel):
+    group: Any
+    count: int
+    examples: List[Any] = Field(default_factory=list)
+
+
+class SummaryResponse(BaseModel):
+    data: List[SummaryItem]
+    report_type: str
+
+
+MAX_LIMIT = 200
+DEFAULT_LIMIT = 50
+SUMMARY_GROUPS = {"Role ID", "User Name", "Risk Level", "Action", "System"}
+
+
+def _parse_date(value: Optional[str]) -> Optional[date]:
+    if value in (None, ""):
+        return None
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:  # noqa: BLE001
+        raise HTTPException(status_code=400, detail=f"Invalid date value '{value}'") from exc
+
+
+def _prepare_columns(columns: Optional[str]) -> Optional[List[str]]:
+    if not columns:
+        return None
+    items = [item.strip() for item in columns.split(",") if item.strip()]
+    if not items:
+        return None
+    return items
+
+
+@router.get("/query", response_model=QueryResponse)
+def query_permissions(
+    *,
+    user: Optional[str] = Query(None, description="Filter by user (substring match)"),
+    role: Optional[str] = Query(None, description="Filter by role ID"),
+    risk_level: Optional[str] = Query(None, description="Filter by risk level"),
+    system: Optional[str] = Query(None, description="Filter by system"),
+    action: Optional[str] = Query(None, description="Filter by permission action"),
+    date_from: Optional[str] = Query(None, description="Filter from date (YYYY-MM-DD)"),
+    date_to: Optional[str] = Query(None, description="Filter to date (YYYY-MM-DD)"),
+    columns: Optional[str] = Query(None, description="Comma separated list of columns"),
+    limit: int = Query(DEFAULT_LIMIT, ge=1, le=MAX_LIMIT),
+    cursor: Optional[str] = Query(None, description="Opaque cursor token"),
+    offset: int = Query(0, ge=0, description="Offset (ignored when cursor is provided)"),
+) -> QueryResponse:
+    bundle = permissions_bundle()
+    parsed_from = _parse_date(date_from)
+    parsed_to = _parse_date(date_to)
+
+    cursor_obj = maybe_decode_cursor(cursor)
+    effective_offset = offset
+    if cursor_obj:
+        if cursor_obj.file_hash != bundle.file_hash:
+            effective_offset = 0
+            cursor_obj = build_initial_cursor(bundle.file_hash, bundle.report_type)
+        else:
+            effective_offset = cursor_obj.offset
+    else:
+        cursor_obj = build_initial_cursor(bundle.file_hash, bundle.report_type, offset)
+
+    lf = bundle.lazyframe
+    lf = apply_filters(
+        lf,
+        user=user,
+        role=role,
+        risk_level=risk_level,
+        system=system,
+        action=action,
+        date_from=parsed_from,
+        date_to=parsed_to,
+    )
+    lf = select_columns(lf, _prepare_columns(columns))
+
+    start = time.perf_counter()
+    rows, has_more = paginate_collect(lf, limit, effective_offset)
+    duration = time.perf_counter() - start
+    partial = duration > 3.0
+
+    if has_more:
+        next_cur = next_cursor(cursor_obj, len(rows))
+        cursor_token = encode_cursor(next_cur)
+    else:
+        cursor_token = None
+
+    log_request_summary(
+        "/risk/permissions/query",
+        filters={
+            "user": user,
+            "role": role,
+            "risk_level": risk_level,
+            "system": system,
+            "action": action,
+            "date_from": date_from,
+            "date_to": date_to,
+        },
+        rows_returned=len(rows),
+        has_more=has_more,
+        partial=partial,
+        latency_ms=int(duration * 1000),
+    )
+
+    return QueryResponse(
+        data=rows,
+        cursor=cursor_token,
+        has_more=has_more,
+        partial=partial,
+        file_hash=bundle.file_hash,
+        report_type=bundle.report_type,
+    )
+
+
+@router.get("/summary", response_model=SummaryResponse)
+def summary_permissions(
+    *,
+    groupby: str = Query(..., description="Column to group by"),
+    top: int = Query(20, ge=1, le=100),
+    user: Optional[str] = None,
+    role: Optional[str] = None,
+    risk_level: Optional[str] = None,
+    system: Optional[str] = None,
+    action: Optional[str] = None,
+    date_from: Optional[str] = None,
+    date_to: Optional[str] = None,
+) -> SummaryResponse:
+    canonical_group = groupby.strip()
+    if canonical_group not in SUMMARY_GROUPS:
+        raise HTTPException(status_code=400, detail="Unsupported groupby column")
+
+    bundle = permissions_bundle()
+    parsed_from = _parse_date(date_from)
+    parsed_to = _parse_date(date_to)
+    lf = apply_filters(
+        bundle.lazyframe,
+        user=user,
+        role=role,
+        risk_level=risk_level,
+        system=system,
+        action=action,
+        date_from=parsed_from,
+        date_to=parsed_to,
+    )
+    records = summarize(lf, canonical_group, top)
+
+    log_request_summary(
+        "/risk/permissions/summary",
+        filters={
+            "groupby": groupby,
+            "user": user,
+            "role": role,
+            "risk_level": risk_level,
+            "system": system,
+            "action": action,
+        },
+        rows_returned=len(records),
+    )
+
+    return SummaryResponse(data=records, report_type=bundle.report_type)

--- a/risk_query_service/security.py
+++ b/risk_query_service/security.py
@@ -1,0 +1,20 @@
+"""API key security dependencies."""
+from __future__ import annotations
+
+from fastapi import HTTPException, Security
+from fastapi.security.api_key import APIKeyHeader
+
+from .config import get_settings
+
+API_KEY_HEADER_NAME = "x-api-key"
+API_KEY_HEADER = APIKeyHeader(name=API_KEY_HEADER_NAME, auto_error=False)
+
+
+def require_api_key(api_key: str | None = Security(API_KEY_HEADER)) -> str:
+    settings = get_settings()
+    expected = settings.api_key
+    if not expected:
+        raise HTTPException(status_code=503, detail="API key is not configured")
+    if not api_key or api_key != expected:
+        raise HTTPException(status_code=401, detail="Invalid API key")
+    return api_key

--- a/risk_query_service/tests/conftest.py
+++ b/risk_query_service/tests/conftest.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from ..config import reset_settings_cache
+from ..file_index import clear_file_cache
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+os.environ.setdefault("ONEDRIVE_LOCAL_PATH", str(FIXTURE_DIR))
+os.environ.setdefault("API_KEY", "test-key")
+
+
+@pytest.fixture(scope="session")
+def client() -> Generator[TestClient, None, None]:
+    reset_settings_cache()
+    clear_file_cache()
+    from ..app import app
+
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches() -> Generator[None, None, None]:
+    clear_file_cache()
+    from ..routers import meta
+
+    meta.schema_cache.clear()
+    yield
+    clear_file_cache()
+    meta.schema_cache.clear()

--- a/risk_query_service/tests/fixtures/RS_Action_Lvl_20240101_000000.txt
+++ b/risk_query_service/tests/fixtures/RS_Action_Lvl_20240101_000000.txt
@@ -1,0 +1,2 @@
+User ID	User Name	User Group	Access Risk ID	Risk Description	Role ID	Risk Level	Function	Function Description	System	Action	Action Description	Last Executed On	Business Process	Composite/Business Role Description
+U999	Legacy User	Ops	R999	Old Risk	ROLE_Z	Low	FUNCZ	Function Zero	SYS0	ACT0	Old Action	2023-12-31	Process Z	Role Desc Z

--- a/risk_query_service/tests/fixtures/RS_Action_Lvl_20240201_120000.txt
+++ b/risk_query_service/tests/fixtures/RS_Action_Lvl_20240201_120000.txt
@@ -1,0 +1,4 @@
+User ID	User Name	User Group	Access Risk ID	Risk Description	Role ID	Risk Level	Function	Function Description	System	Action	Action Description	Last Executed On	Business Process	Composite/Business Role Description
+U001	Alice Smith	Finance	R001	Approval Risk	ROLE_A	High	FUNC1	Function One	SYS1	ACT1	Approve Payment	2024-01-10	Process A	Role Desc A
+U002	Bob Jones	Finance	R002	Access Risk	ROLE_B	Medium	FUNC2	Function Two	SYS1	ACT2	View Report	2024-01-09	Process B	Role Desc B
+U003	Carla Diaz	Sales	R003	Segregation Risk	ROLE_C	High	FUNC3	Function Three	SYS2	ACT3	Create Order	2024-01-05	Process C	Role Desc C

--- a/risk_query_service/tests/fixtures/RS_CritAction_Lvl_20240201_130000.txt
+++ b/risk_query_service/tests/fixtures/RS_CritAction_Lvl_20240201_130000.txt
@@ -1,0 +1,3 @@
+User ID	User Name	User Group	Access Risk ID	Risk Description	Role ID	Risk Level	Function	Function Description	System	Action	Action Description	Last Executed On	Business Process	Composite/Business Role Description
+U004	Dana West	Finance	R004	Critical Risk	ROLE_D	Critical	FUNC4	Function Four	SYS3	ACT4	Override Control	2024-01-08	Process D	Role Desc D
+U005	Evan Lee	IT	R005	Critical Risk	ROLE_E	High	FUNC5	Function Five	SYS3	ACT5	Delete Data	2024-01-07	Process E	Role Desc E

--- a/risk_query_service/tests/fixtures/RS_CritPerm_Lvl_20240201_150000.txt
+++ b/risk_query_service/tests/fixtures/RS_CritPerm_Lvl_20240201_150000.txt
@@ -1,0 +1,2 @@
+User ID	User Name	User Group	Access Risk ID	Risk Description	Role ID	Risk Level	Function	Function Description	System	Action	Action Description	Last Executed On	Business Process	Composite/Business Role Description
+U012	Henry Ivy	IT	PR003	Crit Perm	ROLE_P3	Critical	PFUNC3	Permission Three	SYS4	PACT3	Super Access	2024-01-03	Process P3	Role Desc P3

--- a/risk_query_service/tests/fixtures/RS_Perm_Lvl_20240201_140000.txt
+++ b/risk_query_service/tests/fixtures/RS_Perm_Lvl_20240201_140000.txt
@@ -1,0 +1,3 @@
+User ID	User Name	User Group	Access Risk ID	Risk Description	Role ID	Risk Level	Function	Function Description	System	Action	Action Description	Last Executed On	Business Process	Composite/Business Role Description
+U010	Frank Hall	Finance	PR001	Perm Risk	ROLE_P1	Medium	PFUNC1	Permission One	SYS4	PACT1	Grant Access	2024-01-06	Process P1	Role Desc P1
+U011	Grace Kim	Sales	PR002	Perm Risk	ROLE_P2	Low	PFUNC2	Permission Two	SYS5	PACT2	Modify Data	2024-01-04	Process P2	Role Desc P2

--- a/risk_query_service/tests/test_meta.py
+++ b/risk_query_service/tests/test_meta.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from fastapi.testclient import TestClient
+
+API_HEADERS = {"x-api-key": "test-key"}
+
+
+def test_schema_endpoint(client: TestClient) -> None:
+    response = client.get("/meta/schema", headers=API_HEADERS)
+    assert response.status_code == 200
+    schema: Dict[str, str] = response.json()
+    assert "User ID" in schema
+    assert "ReportType" in schema
+
+
+def test_facets_endpoint(client: TestClient) -> None:
+    response = client.get("/meta/facets", params={"column": "Risk Level", "n": 5}, headers=API_HEADERS)
+    assert response.status_code == 200
+    facets = response.json()
+    assert any(item["value"] == "High" for item in facets)

--- a/risk_query_service/tests/test_pagination.py
+++ b/risk_query_service/tests/test_pagination.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+API_HEADERS = {"x-api-key": "test-key"}
+
+
+def test_cursor_pagination(client: TestClient) -> None:
+    first = client.get(
+        "/risk/actions/query",
+        params={"limit": 1, "columns": "User Name,Risk Level"},
+        headers=API_HEADERS,
+    )
+    assert first.status_code == 200
+    payload = first.json()
+    assert payload["has_more"] is True
+    cursor = payload["cursor"]
+    assert cursor
+    first_name = payload["data"][0]["User Name"]
+
+    second = client.get(
+        "/risk/actions/query",
+        params={"limit": 1, "cursor": cursor},
+        headers=API_HEADERS,
+    )
+    assert second.status_code == 200
+    payload2 = second.json()
+    assert payload2["data"]
+    assert payload2["data"][0]["User Name"] != first_name or payload2["has_more"] is False

--- a/risk_query_service/tests/test_query.py
+++ b/risk_query_service/tests/test_query.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+API_HEADERS = {"x-api-key": "test-key"}
+
+
+def test_actions_query_filter(client: TestClient) -> None:
+    response = client.get(
+        "/risk/actions/query",
+        params={"risk_level": "High", "limit": 5},
+        headers=API_HEADERS,
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["has_more"] in {True, False}
+    assert payload["report_type"] == "actions"
+    for row in payload["data"]:
+        assert row["Risk Level"].lower() == "high"
+
+
+def test_permissions_query_user_search(client: TestClient) -> None:
+    response = client.get(
+        "/risk/permissions/query",
+        params={"user": "Frank", "limit": 5},
+        headers=API_HEADERS,
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["data"]
+    assert payload["data"][0]["User Name"] == "Frank Hall"

--- a/risk_query_service/tests/test_summary.py
+++ b/risk_query_service/tests/test_summary.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+API_HEADERS = {"x-api-key": "test-key"}
+
+
+def test_actions_summary_groupby(client: TestClient) -> None:
+    response = client.get(
+        "/risk/actions/summary",
+        params={"groupby": "Risk Level", "top": 10},
+        headers=API_HEADERS,
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    levels = {item["group"] for item in payload["data"]}
+    assert "High" in levels
+    assert payload["report_type"] == "actions"
+
+
+def test_permissions_summary_groupby(client: TestClient) -> None:
+    response = client.get(
+        "/risk/permissions/summary",
+        params={"groupby": "System"},
+        headers=API_HEADERS,
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    systems = {item["group"] for item in payload["data"]}
+    assert "SYS4" in systems

--- a/risk_query_service/utils/logging.py
+++ b/risk_query_service/utils/logging.py
@@ -1,0 +1,35 @@
+"""Logging helpers using loguru."""
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict
+
+from loguru import logger
+
+
+def configure_logging() -> None:
+    """Configure loguru to emit JSON lines suitable for production."""
+
+    logger.remove()
+
+    def _serialize(record: Dict[str, Any]) -> str:
+        payload = {
+            "timestamp": record["time"].isoformat(),
+            "level": record["level"].name,
+            "message": record["message"],
+            "module": record["module"],
+            "function": record["function"],
+            "line": record["line"],
+        }
+        payload.update(record.get("extra", {}))
+        return json.dumps(payload, default=str)
+
+    sink = os.environ.get("LOG_FILE") or "sys.stderr"
+    logger.add(sink, level="INFO", serialize=False, backtrace=False, diagnose=False, format=_serialize)
+
+
+def log_request_summary(endpoint: str, **extra: Any) -> None:
+    """Helper to log structured request summary."""
+
+    logger.bind(endpoint=endpoint, **extra).info("request-summary")

--- a/risk_query_service/utils/paginate.py
+++ b/risk_query_service/utils/paginate.py
@@ -1,0 +1,46 @@
+"""Cursor-based pagination helpers."""
+from __future__ import annotations
+
+import base64
+import json
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class Cursor:
+    offset: int
+    file_hash: str
+    report_type: str
+
+
+class CursorError(ValueError):
+    """Raised when the cursor token cannot be decoded."""
+
+
+def encode_cursor(cursor: Cursor) -> str:
+    payload = json.dumps(cursor.__dict__, separators=(",", ":"))
+    return base64.urlsafe_b64encode(payload.encode("utf-8")).decode("utf-8")
+
+
+def decode_cursor(token: str) -> Cursor:
+    try:
+        raw = base64.urlsafe_b64decode(token.encode("utf-8"))
+        data = json.loads(raw.decode("utf-8"))
+        return Cursor(offset=int(data["offset"]), file_hash=str(data["file_hash"]), report_type=str(data["report_type"]))
+    except Exception as exc:  # noqa: BLE001
+        raise CursorError("Invalid cursor token") from exc
+
+
+def next_cursor(current: Cursor, advance: int) -> Cursor:
+    return Cursor(offset=current.offset + advance, file_hash=current.file_hash, report_type=current.report_type)
+
+
+def build_initial_cursor(file_hash: str, report_type: str, offset: int = 0) -> Cursor:
+    return Cursor(offset=offset, file_hash=file_hash, report_type=report_type)
+
+
+def maybe_decode_cursor(token: Optional[str]) -> Optional[Cursor]:
+    if not token:
+        return None
+    return decode_cursor(token)

--- a/risk_query_service/utils/schema.py
+++ b/risk_query_service/utils/schema.py
@@ -1,0 +1,72 @@
+"""Schema utilities for the risk query service."""
+from __future__ import annotations
+
+from typing import Dict, List
+
+import polars as pl
+
+CANONICAL_COLUMNS: List[str] = [
+    "User ID",
+    "User Name",
+    "User Group",
+    "Access Risk ID",
+    "Risk Description",
+    "Role ID",
+    "Risk Level",
+    "Function",
+    "Function Description",
+    "System",
+    "Action",
+    "Action Description",
+    "Last Executed On",
+    "Business Process",
+    "Composite/Business Role Description",
+    "ReportType",
+    "IsCritical",
+]
+
+DEFAULT_COLUMNS: List[str] = [
+    "User ID",
+    "User Name",
+    "Role ID",
+    "Risk Level",
+    "Action",
+    "Action Description",
+    "System",
+    "Last Executed On",
+    "IsCritical",
+    "ReportType",
+]
+
+CANONICAL_TYPES: Dict[str, pl.DataType] = {
+    "User ID": pl.Utf8,
+    "User Name": pl.Utf8,
+    "User Group": pl.Utf8,
+    "Access Risk ID": pl.Utf8,
+    "Risk Description": pl.Utf8,
+    "Role ID": pl.Utf8,
+    "Risk Level": pl.Utf8,
+    "Function": pl.Utf8,
+    "Function Description": pl.Utf8,
+    "System": pl.Utf8,
+    "Action": pl.Utf8,
+    "Action Description": pl.Utf8,
+    "Last Executed On": pl.Utf8,
+    "Business Process": pl.Utf8,
+    "Composite/Business Role Description": pl.Utf8,
+    "ReportType": pl.Utf8,
+    "IsCritical": pl.Boolean,
+}
+
+
+def canonicalize_columns(columns: List[str]) -> List[str]:
+    """Return canonical columns while preserving the requested order."""
+
+    canon = {name.lower(): name for name in CANONICAL_COLUMNS}
+    resolved: List[str] = []
+    for column in columns:
+        key = column.lower()
+        if key not in canon:
+            raise KeyError(f"Unknown column: {column}")
+        resolved.append(canon[key])
+    return resolved

--- a/risk_query_service/utils/swagger2.py
+++ b/risk_query_service/utils/swagger2.py
@@ -1,0 +1,95 @@
+"""Convert OpenAPI 3.0 schemas to Swagger 2.0 at runtime."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+class SwaggerConversionError(RuntimeError):
+    """Raised when conversion cannot be completed."""
+
+
+def convert_openapi3_to_swagger2(openapi_schema: Dict[str, Any]) -> Dict[str, Any]:
+    """Perform a minimal conversion from OpenAPI 3.0 to Swagger 2.0."""
+
+    if "openapi" not in openapi_schema:
+        raise SwaggerConversionError("Expected an OpenAPI 3.0 schema")
+
+    swagger: Dict[str, Any] = {
+        "swagger": "2.0",
+        "info": openapi_schema.get("info", {}),
+        "paths": {},
+        "definitions": {},
+    }
+
+    servers = openapi_schema.get("servers", [])
+    if servers:
+        url = servers[0].get("url", "")
+        if url.startswith("http://"):
+            swagger["schemes"] = ["http"]
+            swagger["host"] = url.replace("http://", "", 1).rstrip("/")
+        elif url.startswith("https://"):
+            swagger["schemes"] = ["https"]
+            swagger["host"] = url.replace("https://", "", 1).rstrip("/")
+        if "/" in swagger.get("host", ""):
+            host, base_path = swagger["host"].split("/", 1)
+            swagger["host"] = host
+            swagger["basePath"] = f"/{base_path}"
+
+    components = openapi_schema.get("components", {})
+    schemas = components.get("schemas", {})
+    swagger["definitions"] = schemas
+
+    security_definitions = components.get("securitySchemes", {})
+    if security_definitions:
+        converted = {}
+        for name, scheme in security_definitions.items():
+            if scheme.get("type") == "apiKey":
+                converted[name] = {
+                    "type": "apiKey",
+                    "name": scheme.get("name"),
+                    "in": scheme.get("in", "header"),
+                }
+        if converted:
+            swagger["securityDefinitions"] = converted
+
+    global_security = openapi_schema.get("security")
+    if global_security:
+        swagger["security"] = global_security
+
+    for path, methods in openapi_schema.get("paths", {}).items():
+        swagger_methods: Dict[str, Any] = {}
+        for method, operation in methods.items():
+            new_operation = dict(operation)
+            responses = new_operation.get("responses", {})
+            for status, response in list(responses.items()):
+                content = response.get("content")
+                if content:
+                    json_schema = content.get("application/json", {}).get("schema")
+                    if json_schema:
+                        response = dict(response)
+                        response["schema"] = json_schema
+                    response.pop("content", None)
+                    responses[status] = response
+            new_operation["responses"] = responses
+
+            parameters = []
+            for param in new_operation.get("parameters", []):
+                param = dict(param)
+                schema = param.pop("schema", None)
+                if schema is not None:
+                    param["type"] = schema.get("type")
+                    if schema.get("enum"):
+                        param["enum"] = schema["enum"]
+                    if schema.get("items"):
+                        param["items"] = schema["items"]
+                    if schema.get("format"):
+                        param["format"] = schema["format"]
+                parameters.append(param)
+            new_operation["parameters"] = parameters
+
+            new_operation.pop("callbacks", None)
+            new_operation.pop("servers", None)
+            swagger_methods[method] = new_operation
+        swagger["paths"][path] = swagger_methods
+
+    return swagger


### PR DESCRIPTION
## Summary
- add a FastAPI application exposing risk action and permission query endpoints backed by Polars lazy datasets
- implement file discovery, Microsoft Graph download fallback, cursor pagination, schema metadata, and Swagger 2.0 export
- provide tests, fixtures, and developer tooling for local runs, Docker builds, and Copilot Studio integration

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e6352fcf28832bba3c22ca0040615b